### PR TITLE
Dont allow dragging on detail view

### DIFF
--- a/resources/js/components/DetailField.vue
+++ b/resources/js/components/DetailField.vue
@@ -38,7 +38,7 @@ export default {
             this.marker = new google.maps.Marker({
                 position: coords,
                 map: this.map,
-                draggable: true
+                draggable: false
             });
 
             this.map.setCenter(coords);


### PR DESCRIPTION
this feels weird: allowing to drag the icon whilst only 'viewing' the map. (ofcourse still allow dragging on edit)